### PR TITLE
CPP for foreign imports, compatibility module for GHCi

### DIFF
--- a/include/foreign-compat.h
+++ b/include/foreign-compat.h
@@ -1,0 +1,8 @@
+#ifdef ghcjs_HOST_OS
+#define FOREIGN_IMPORT(safety,name,type,str) \
+  ;foreign import javascript safety str name :: type
+#else
+#define FOREIGN_IMPORT(safety,name,type,str) \
+  ;name :: type \
+  ;name = error "'name' (a foreign import) is not defined. This is a stub to support type-checking in GHCi."
+#endif

--- a/reflex-dom-semui.cabal
+++ b/reflex-dom-semui.cabal
@@ -6,15 +6,23 @@ author:              Doug Beardsley
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  include/foreign-compat.h
 
 library
   hs-source-dirs: src
+  include-dirs: include
   js-sources:
     -- lib/jquery.min.js,
     lib/semantic.min.js
 
   exposed-modules:
     Reflex.Dom.SemanticUI
+
+  other-modules:
+    GHCJS.Compat
+    Reflex.Dom.SemanticUI.Button
+    Reflex.Dom.SemanticUI.Common
+    Reflex.Dom.SemanticUI.Dropdown
 
   build-depends:
       base
@@ -27,10 +35,14 @@ library
     , text
 
   if impl(ghcjs)
+    hs-source-dirs: src-ghcjs
     build-depends: ghcjs-base
+  else
+    hs-source-dirs: src-ghc
 
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-orphans
   cpp-options: -D_GHCJS_ -DGHCJS_GC_INTERVAL=60000
 
   default-language:    Haskell2010
-
+  default-extensions:
+    CPP

--- a/src-ghc/GHCJS/Compat.hs
+++ b/src-ghc/GHCJS/Compat.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -fno-warn-missing-methods #-}
+
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances    #-}
+
+module GHCJS.Compat where
+
+import Data.String (IsString)
+import Data.Text (Text)
+
+data JSVal
+
+pFromJSVal :: JSVal -> JSString
+pFromJSVal = undefined
+
+data JSString
+instance IsString JSString
+
+class ToJSString a
+instance ToJSString [Char]
+instance ToJSString Text
+
+toJSString :: ToJSString a => a -> JSString
+toJSString = undefined
+
+class FromJSString a
+instance FromJSString [Char]
+instance FromJSString Text
+
+fromJSString :: FromJSString a => JSString -> a
+fromJSString = undefined
+
+toJSBool :: Bool -> JSVal
+toJSBool = undefined
+
+data Callback a
+
+data OnBlocked
+  = ContinueAsync
+  | ThrowWouldBlock
+
+syncCallback :: OnBlocked -> IO () -> IO (Callback (IO ()))
+syncCallback = undefined
+
+syncCallback1 :: OnBlocked -> (JSVal -> IO ()) -> IO (Callback (JSVal -> IO ()))
+syncCallback1 = undefined
+
+asyncCallback1 :: (JSVal -> IO ()) -> IO (Callback (JSVal -> IO ()))
+asyncCallback1 = undefined
+
+asyncCallback2 :: (JSVal -> JSVal -> IO ()) -> IO (Callback (JSVal -> JSVal -> IO ()))
+asyncCallback2 = undefined
+
+asyncCallback3 :: (JSVal -> JSVal -> JSVal -> IO ()) -> IO (Callback (JSVal -> JSVal -> JSVal -> IO ()))
+asyncCallback3 = undefined
+
+releaseCallback :: Callback a -> IO ()
+releaseCallback = undefined

--- a/src-ghcjs/GHCJS/Compat.hs
+++ b/src-ghcjs/GHCJS/Compat.hs
@@ -1,0 +1,7 @@
+module GHCJS.Compat (module X) where
+
+import GHCJS.Foreign.Callback as X
+import GHCJS.Foreign          as X
+import GHCJS.Marshal.Internal as X
+import GHCJS.Types            as X
+import GHCJS.DOM.Types        as X (ToJSString, FromJSString, toJSString, fromJSString)


### PR DESCRIPTION
The `FOREIGN_IMPORT()` macro makes it really easy to declare foreign import that works in GHCJS and compiles in GHC.

The compatibility module `GHCJS.Compat` hides the GHC stubs and cleans up the main code.
