### PR TITLE
Add the beginnings of example code as a test-suite

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Data.Map (Map)
+import Data.Text (Text)
+import Reflex.Dom
+import Reflex.Dom.SemanticUI
+
+main :: IO ()
+main = mainWidget $ do
+  el "p" $ text "These are examples of semantic-ui widgets."
+  el "p" $ uiButton (huge $ inverted $ blue def) (text "I'm a huge, inverted, blue button!")

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="rts.js"></script>
+    <script src="lib.js"></script>
+    <script src="out.js"></script>
+    <link rel="stylesheet" type="text/css" media="screen" href="semantic.min.css">
+  </head>
+  <body>
+  </body>
+  <script language="javascript" src="runmain.js" defer></script>
+</html>

--- a/reflex-dom-semui.cabal
+++ b/reflex-dom-semui.cabal
@@ -12,8 +12,9 @@ library
   hs-source-dirs: src
   include-dirs: include
   js-sources:
-    -- lib/jquery.min.js,
-    lib/semantic.min.js
+    -- Order is important: jquery is used by semantic but must come after.
+    lib/semantic.min.js,
+    lib/jquery.min.js
 
   exposed-modules:
     Reflex.Dom.SemanticUI
@@ -46,3 +47,21 @@ library
   default-language:    Haskell2010
   default-extensions:
     CPP
+
+test-suite example
+  type:              exitcode-stdio-1.0
+  main-is:           Main.hs
+  hs-source-dirs:    example
+  default-language:  Haskell2010
+  default-extensions:
+    CPP
+
+  build-depends:
+      base
+    , containers
+    , dependent-sum
+    , mtl
+    , reflex            >= 0.5 && < 0.6
+    , reflex-dom        >= 0.4 && < 0.5
+    , reflex-dom-semui
+    , text

--- a/src/Reflex/Dom/SemanticUI/Common.hs
+++ b/src/Reflex/Dom/SemanticUI/Common.hs
@@ -15,14 +15,19 @@
 module Reflex.Dom.SemanticUI.Common where
 
 ------------------------------------------------------------------------------
+import           Data.Default
 import           Data.Text (Text)
 import qualified Data.Text as T
+import           Reflex.Dom
 ------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------
 -- | Temporary...will be moved out of here eventually.
 tshow :: Show a => a -> Text
 tshow = T.pack . show
+
+instance (Default a, Reflex t) => Default (Dynamic t a) where
+  def = constDyn def
 
 ------------------------------------------------------------------------------
 -- | A type class for converting data types into appropriate  Semantic UI
@@ -64,6 +69,9 @@ instance UiClassText UiColor where
 
 class UiHasColor a where
   uiSetColor :: UiColor -> a -> a
+
+instance (Reflex t, UiHasColor a) => UiHasColor (Dynamic t a) where
+  uiSetColor c = fmap (uiSetColor c)
 
 red, orange, yellow, olive, green, teal, blue, violet, purple, pink, brown, grey, black
   :: UiHasColor a => a -> a
@@ -124,6 +132,9 @@ instance UiClassText UiInverted where
 class UiHasInverted a where
   inverted :: a -> a
 
+instance (Reflex t, UiHasInverted a) => UiHasInverted (Dynamic t a) where
+  inverted = fmap inverted
+
 ------------------------------------------------------------------------------
 data UiActivation
   = UiActive
@@ -165,6 +176,9 @@ instance UiClassText UiSize where
 
 class UiHasSize a where
   uiSetSize :: UiSize -> a -> a
+
+instance (Reflex t, UiHasSize a) => UiHasSize (Dynamic t a) where
+  uiSetSize c = fmap (uiSetSize c)
 
 mini, tiny, small, medium, large, big, huge, massive :: UiHasSize a => a -> a
 mini = uiSetSize UiMini


### PR DESCRIPTION
**WARNING**: This PR currently builds on #3 due to a conflict in `reflex-dom-semui.cabal`. Whether or not you merge #3, I'm happy to rebase to fix this.

I implemented a test-suite to demonstrate examples of the widgets in use and in presentation. I imagine that this code will grow along with the widgets as they are defined. It can serve as a test to check that type signatures are unchanged and that the output still renders and behaves the same. It can also serve as the go-to source for showing others how to use the widgets.

I added straightforward instances for `Dynamic` with some of the type classes used in the example code. I'm not sure if that's how you envisioned those classes working, but it made sense to me.

Currently, it's a little bit of work to get the example loaded in the browser. I build the test  executable JavaScript, copy `lib/*` and `example/index.html` to the output directory, and load the `index.html` in the browser. I'm sure there is a better way to do this.
