### PR TITLE
Put FOREIGN_IMPORT comment in foreign-compat.h

### DIFF
--- a/include/foreign-compat.h
+++ b/include/foreign-compat.h
@@ -1,3 +1,10 @@
+-- This macro allows you to define a 'foreign import javascript' for GHCJS that
+-- will be a typed stub with a meaningful error in GHC.
+--
+-- NOTE: You should use this macro in a single line, not across multiple lines.
+-- That is, write FOREIGN_IMPORT(A, B, C, D) all on one line. Some CPPs like the
+-- one used by clang will fail if the macro application spans multiple lines.
+
 #ifdef ghcjs_HOST_OS
 #define FOREIGN_IMPORT(safety,name,type,str) \
   ;foreign import javascript safety str name :: type

--- a/src/Reflex/Dom/SemanticUI/Dropdown.hs
+++ b/src/Reflex/Dom/SemanticUI/Dropdown.hs
@@ -12,9 +12,9 @@
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE UndecidableInstances     #-}
 
-module Reflex.Dom.SemanticUI.Dropdown where
-
 #include "foreign-compat.h"
+
+module Reflex.Dom.SemanticUI.Dropdown where
 
 ------------------------------------------------------------------------------
 --import           Control.Lens
@@ -40,8 +40,6 @@ import           Reflex.Dom.SemanticUI.Common (tshow)
 activateSemUiDropdown :: Text -> IO ()
 activateSemUiDropdown = js_activateSemUiDropdown . toJSString
 
--- NOTE: For some reason on Mac you can't split the foreign import macro
--- across multiple lines.
 FOREIGN_IMPORT(unsafe, js_activateSemUiDropdown, JSString -> IO (), "$($1).dropdown({fullTextSearch: true});")
 
 data DropdownMulti t a = DropdownMulti


### PR DESCRIPTION
I think it's better if the comment is at the source of the problem. Also, I put the `#include` above the `module` declaration to avoid accidentally messing with `import`s and in case it might later include a language extension.
