### PR TITLE
Checkboxes now use initial value from config (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ A compiled version of the code in the `example` folder is available in `docs/ind
 To rebuild the example app and update the `docs` folder, just run
 
     cabal configure --ghcjs --enable-tests
-    cabal build example && makedocs.sh
+    cabal build example && ./makedocs.sh
 

--- a/example/CountryEnum.hs
+++ b/example/CountryEnum.hs
@@ -6,7 +6,7 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Prelude hiding (GT, LT)
-import Reflex.Dom
+import Reflex.Dom.Core
 
 flag :: MonadWidget t m => Text -> m ()
 flag flagType = elClass "i" (flagType <> " flag") blank

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -12,9 +12,8 @@ import Data.Map (Map, fromList)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
-import Reflex.Dom
+import Reflex.Dom.Core
 import Reflex.Dom.SemanticUI
-import Reflex.Dom.Internal () -- TODO remove this once we solve orphan instance issue
 
 import StateEnum
 import CountryEnum
@@ -88,9 +87,10 @@ checkboxes = do
             def & setValue .~ (False <$ resetEvent)
           divClass "ui left pointing label" $ display $ value c1
         divClass "ui compact segment" $ do
-          c2 <- uiCheckbox (text "Toggle checkbox") $
+          c2 <- uiCheckbox (text "Toggle checkbox (checked by default)") $
             def & checkboxConf_type .~ [CbToggle]
-                & setValue .~ (False <$ resetEvent)
+                & setValue .~ (True <$ resetEvent)
+                & checkboxConf_initialValue .~ True
           divClass "ui left pointing label" $ display $ value c2
         divClass "ui compact segment" $ do
           c3 <- uiCheckbox (text "Slider checkbox") $

--- a/example/StateEnum.hs
+++ b/example/StateEnum.hs
@@ -6,7 +6,7 @@ import Prelude hiding (GT, LT)
 
 import Data.Text (Text)
 import qualified Data.Text as T
-import Reflex.Dom
+import Reflex.Dom.Core
 
 data StateEnum
   = AL | AK | AZ | AR | CA | CO | CT | DE | DC | FL | GA | HI | ID | IL | IN

--- a/reflex-dom-semui.cabal
+++ b/reflex-dom-semui.cabal
@@ -77,7 +77,7 @@ test-suite example
     , lens
     , mtl
     , reflex            >= 0.5 && < 0.6
-    , reflex-dom        >= 0.4 && < 0.5
+    , reflex-dom-core   >= 0.4 && < 0.5
     , reflex-dom-semui
     , text
 

--- a/src/Reflex/Dom/SemanticUI/Checkbox.hs
+++ b/src/Reflex/Dom/SemanticUI/Checkbox.hs
@@ -135,13 +135,14 @@ uiCheckbox' label config = do
 
   -- Setup the event and callback function for when the value is changed
   (onChangeEvent, onChangeCallback) <- newTriggerEvent
+  let setCbVal = setCheckboxValue (_element_raw cbEl)
 
-  -- Activate the dropdown after build
-  schedulePostBuild $ liftJSM $
+  -- Activate the dropdown after build and set initial value
+  schedulePostBuild $ liftJSM $ do
     activateCheckbox (_element_raw cbEl) $ liftIO . onChangeCallback
+    setCbVal $ _checkboxConf_initialValue config
 
   -- Allow the value to be set
-  let setCbVal = setCheckboxValue (_element_raw cbEl)
   performEvent_ $ liftJSM . setCbVal <$> _checkboxConf_setValue config
 
   cb <- holdDyn (M.member "checked" attrs) onChangeEvent


### PR DESCRIPTION
For some reason I can't get the example to configure with reflex-dom any more. I changed it to reflex-dom-core since it doesn't really matter for the simple example app.
